### PR TITLE
Scan Build Security Issues (15)

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
       - develop
   pull_request:
     branches:
-      - master
+      - main
       - develop
 
 jobs:

--- a/src/eos_parse.c
+++ b/src/eos_parse.c
@@ -210,7 +210,7 @@ void parsePermissionField(uint8_t *in, uint32_t inLength, const char fieldName[]
     uint32_t accountWrittenLength = 0;
     
     parseNameField(in, inLength, fieldName, arg, read, &accountWrittenLength);
-    strlcat(arg->data, "@", 1);
+    strlcat(arg->data, "@", sizeof(arg->data));
     
     in += *read; inLength -= *read;
     if (inLength < sizeof(name_t)) {

--- a/src/eos_parse.c
+++ b/src/eos_parse.c
@@ -1,4 +1,8 @@
 /*******************************************************************************
+*   EOS Network Foundation
+*   (c) 2022 EOS Network Foundation
+*   All changes with MIT License see ./License file.
+*
 *   Taras Shchybovyk
 *   (c) 2018 Taras Shchybovyk
 *
@@ -195,7 +199,6 @@ void parseStringField(uint8_t *in, uint32_t inLength, const char fieldName[], ac
     }
 
     in += readFromBuffer;
-    inLength -= readFromBuffer;
 
     memmove(arg->data, in, fieldLength);
 
@@ -207,7 +210,7 @@ void parsePermissionField(uint8_t *in, uint32_t inLength, const char fieldName[]
     uint32_t accountWrittenLength = 0;
     
     parseNameField(in, inLength, fieldName, arg, read, &accountWrittenLength);
-    strcat(arg->data, "@");
+    strlcat(arg->data, "@", 1);
     
     in += *read; inLength -= *read;
     if (inLength < sizeof(name_t)) {

--- a/src/eos_parse_eosio.c
+++ b/src/eos_parse_eosio.c
@@ -23,6 +23,7 @@
 #include "eos_types.h"
 #include "os.h"
 #include "string.h"
+#include "stdio.h"
 
 void parseDelegate(uint8_t *buffer, uint32_t bufferLength, uint8_t argNum, actionArgument_t *arg) {
     uint32_t read = 0;
@@ -161,8 +162,9 @@ void parseUpdateAuth(uint8_t *buffer, uint32_t bufferLength, uint8_t argNum, act
         parseNameField(buffer, bufferLength, "Permission", arg, &read, &written);
         return;
     }
-    
-    uint8_t *parentBuffer = buffer + 2 * sizeof(name_t);
+
+    // added parens for clarity and safety
+    uint8_t *parentBuffer = buffer + (2 * sizeof(name_t));
     name_t parent = 0;
     memmove(&parent, parentBuffer, sizeof(name_t));
     if (parent != 0 && argNum == 2) {
@@ -180,10 +182,12 @@ void parseUpdateAuth(uint8_t *buffer, uint32_t bufferLength, uint8_t argNum, act
         return;
     }
 
-    // moved buffer build before keys assigment, previously inline and dead-code
-    buffer += 3 * sizeof(name_t) + sizeof(uint32_t);
+    // for clarity broke out assignment into several lines
+    // prefixLength calculated once was calculated twice
+    uint32_t prefixLength = 3 * sizeof(name_t) + sizeof(uint32_t);
+    buffer += prefixLength;
     uint8_t *keys = buffer;
-    uint32_t keyBufferLength = bufferLength - 3 * sizeof(name_t) + sizeof(uint32_t);
+    uint32_t keyBufferLength = bufferLength - prefixLength ;
 
     uint32_t totalKeys = 0;
     read = unpack_variant32(keys, keyBufferLength, &totalKeys);

--- a/src/eos_parse_eosio.c
+++ b/src/eos_parse_eosio.c
@@ -18,6 +18,7 @@
 #include "eos_parse_eosio.h"
 #include "eos_types.h"
 #include "os.h"
+#include "string.h"
 
 void parseDelegate(uint8_t *buffer, uint32_t bufferLength, uint8_t argNum, actionArgument_t *arg) {
     uint32_t read = 0;

--- a/src/eos_parse_eosio.c
+++ b/src/eos_parse_eosio.c
@@ -1,4 +1,8 @@
 /*******************************************************************************
+*   EOS Network Foundation
+*   (c) 2022 EOS Network Foundation
+*   All changes with MIT License see ./License file.
+*
 *   Taras Shchybovyk
 *   (c) 2018 Taras Shchybovyk
 *
@@ -176,7 +180,9 @@ void parseUpdateAuth(uint8_t *buffer, uint32_t bufferLength, uint8_t argNum, act
         return;
     }
 
-    uint8_t *keys = buffer += 3 * sizeof(name_t) + sizeof(uint32_t);
+    // moved buffer build before keys assigment, previously inline and dead-code
+    buffer += 3 * sizeof(name_t) + sizeof(uint32_t);
+    uint8_t *keys = buffer;
     uint32_t keyBufferLength = bufferLength - 3 * sizeof(name_t) + sizeof(uint32_t);
 
     uint32_t totalKeys = 0;

--- a/src/eos_stream.c
+++ b/src/eos_stream.c
@@ -135,7 +135,7 @@ static void processEosioVoteProducer(txProcessingContext_t *context) {
     context->content->argumentCount += totalProducers;
 }
 
-static inline void eos_assert(x) {
+static inline void eos_assert(bool x) {
     if (!x) {
         THROW(STREAM_FAULT);
     }
@@ -953,7 +953,7 @@ static parserStatus_e processTxInternal(txProcessingContext_t *context) {
  * way as possible, as EOS transaction size isn't fixed
  * and depends on action size. 
  * Also, Ledger Nano S have limited RAM resource, so data caching
- * could be very expencive. Due to these features and limitations
+ * could be very expensive. Due to these features and limitations
  * only some fields are cached before processing. 
  * All data is encoded by DER.ASN1 rules in plain way and serialized as a flat map.
  * 
@@ -966,7 +966,7 @@ static parserStatus_e processTxInternal(txProcessingContext_t *context) {
  *  [Tag][Length][Value]
  * [0x04][ 0x20 ][chain id as octet string]
  * 
- * More infomation about DER Tag Length Value encoding is here: http://luca.ntop.org/Teaching/Appunti/asn1.html.
+ * More information about DER Tag Length Value encoding is here: http://luca.ntop.org/Teaching/Appunti/asn1.html.
  * Only octet tag number is allowed. 
  * Value is encoded as octet string.
  * The length of the string is stored in Length byte(s)

--- a/src/eos_stream.c
+++ b/src/eos_stream.c
@@ -291,7 +291,9 @@ static void processEosioNewAccountAction(txProcessingContext_t *context) {
         THROW(EXCEPTION);
     }
     buffer += read; bufferLength -= read;
-    read = unpack_variant32(buffer, bufferLength, &size);
+    // unpack typically returns read variable
+    // ignoring return value we only care about pass by reference size
+    unpack_variant32(buffer, bufferLength, &size);
     if (size != 0) {
         PRINTF("No delays allowed");
         THROW(EXCEPTION);

--- a/src/eos_stream.c
+++ b/src/eos_stream.c
@@ -1,4 +1,8 @@
 /*******************************************************************************
+*   EOS Network Foundation
+*   (c) 2022 EOS Network Foundation
+*   All changes with MIT License see ./License file.
+*
 *   Taras Shchybovyk
 *   (c) 2018 Taras Shchybovyk
 *
@@ -86,7 +90,6 @@ static void processTokenTransfer(txProcessingContext_t *context) {
 
 static void processEosioDelegate(txProcessingContext_t *context) {
     context->content->argumentCount = 4;
-    uint32_t bufferLength = context->currentActionDataBufferLength;
     uint8_t *buffer = context->actionDataBuffer;
 
     buffer += 2 * sizeof(name_t) + 2 * sizeof(asset_t);

--- a/src/eos_stream.h
+++ b/src/eos_stream.h
@@ -1,4 +1,8 @@
 /*******************************************************************************
+*   EOS Network Foundation
+*   (c) 2022 EOS Network Foundation
+*   All changes with MIT License see ./License file.
+*
 *   Taras Shchybovyk
 *   (c) 2018 Taras Shchybovyk
 *

--- a/src/main.c
+++ b/src/main.c
@@ -163,7 +163,7 @@ UX_STEP_CB(
     switch_settings_contract_data(),
     {
       .title = "Contract data",
-      .text = confirmLabel,
+      .text = (char *) confirmLabel,
     });
 
 #else
@@ -267,7 +267,7 @@ UX_STEP_NOCB(
     {
       &C_icon_certificate,
       "Review",
-      confirmLabel,
+      (char *) confirmLabel,
     });
 UX_STEP_NOCB(
     ux_single_action_sign_flow_2_step,
@@ -316,8 +316,8 @@ UX_STEP_CB(
     ux_single_action_sign_flow_ok_pressed(),
     {
       &C_icon_validate_14,
-      confirm_text1,
-      confirm_text2,
+      (char *) confirm_text1,
+      (char *) confirm_text2,
     });
 UX_STEP_CB(
     ux_single_action_sign_flow_8_step,
@@ -432,7 +432,7 @@ UX_FLOW_DEF_NOCB(
     bn, //pnn,
     {
       "With",
-      actionCounter,
+      (char *) actionCounter,
     });
 UX_FLOW_DEF_VALID(
     ux_multiple_action_sign_flow_3_step,

--- a/src/main.c
+++ b/src/main.c
@@ -193,8 +193,8 @@ UX_FLOW(
 );
 
 void display_settings() {
-  strcpy(confirmLabel, (N_storage.dataAllowed ? "Allowed" : "NOT Allowed"));
-  ux_flow_init(0, ux_settings_flow, NULL);
+    strlcpy((char *) confirmLabel, (N_storage.dataAllowed ? allowed : not_allowed),32);
+    ux_flow_init(0, ux_settings_flow, NULL);
 }
 
 void switch_settings_contract_data() {

--- a/src/main.c
+++ b/src/main.c
@@ -509,14 +509,14 @@ void ui_idle(void)
     ux_flow_init(0, ux_idle_flow, NULL);
 }
 
-unsigned int io_seproxyhal_touch_exit(const bagl_element_t *e)
+unsigned int io_seproxyhal_touch_exit(__attribute__((unused)) const bagl_element_t *e)
 {
     // Go back to the dashboard
     os_sched_exit(0);
     return 0; // do not redraw the widget
 }
 
-unsigned int io_seproxyhal_touch_address_ok(const bagl_element_t *e)
+unsigned int io_seproxyhal_touch_address_ok(__attribute__((unused)) const bagl_element_t *e)
 {
     uint32_t tx = get_public_key_and_set_result();
     io_exchange_with_code(0x9000, tx);
@@ -525,7 +525,7 @@ unsigned int io_seproxyhal_touch_address_ok(const bagl_element_t *e)
     return 0; // do not redraw the widget
 }
 
-unsigned int io_seproxyhal_touch_address_cancel(const bagl_element_t *e)
+unsigned int io_seproxyhal_touch_address_cancel(__attribute__((unused)) const bagl_element_t *e)
 {
     io_exchange_with_code(0x6985, 0);
     // Display back the original UX
@@ -533,7 +533,7 @@ unsigned int io_seproxyhal_touch_address_cancel(const bagl_element_t *e)
     return 0; // do not redraw the widget
 }
 
-unsigned int io_seproxyhal_touch_tx_ok(const bagl_element_t *e)
+unsigned int io_seproxyhal_touch_tx_ok(__attribute__((unused)) const bagl_element_t *e)
 {
     uint32_t tx = sign_hash_and_set_result();
     io_exchange_with_code(0x9000, tx);
@@ -543,7 +543,7 @@ unsigned int io_seproxyhal_touch_tx_ok(const bagl_element_t *e)
     return 0; // do not redraw the widge
 }
 
-unsigned int io_seproxyhal_touch_tx_cancel(const bagl_element_t *e)
+unsigned int io_seproxyhal_touch_tx_cancel(__attribute__((unused)) const bagl_element_t *e)
 {
     io_exchange_with_code(0x6985, 0);
     // Display back the original UX

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,8 @@
 /*******************************************************************************
+*   EOS Network Foundation
+*   (c) 2022 EOS Network Foundation
+*   All changes with MIT License see ./License file.
+*
 *   Taras Shchybovyk
 *   (c) 2018 Taras Shchybovyk
 *
@@ -193,7 +197,6 @@ UX_FLOW(
 );
 
 void display_settings() {
-    // Review: cast destination string from volatile char to char is that ok?
     strlcpy((char *) confirmLabel, (N_storage.dataAllowed ?  "Allowed" : "NOT Allowed"),sizeof(confirmLabel));
     ux_flow_init(0, ux_settings_flow, NULL);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -716,7 +716,9 @@ uint32_t sign_hash_and_set_result(void)
             rng_rfc6979(G_io_apdu_buffer + 100, tmpCtx.transactionContext.hash, NULL, 0, SECP256K1_N, 32, V, K);
         }
         uint32_t infos;
-        tx = cx_ecdsa_sign(&privateKey, CX_NO_CANONICAL | CX_RND_PROVIDED | CX_LAST, CX_SHA256,
+        // ignores returns signature length which is always 64, we always return length of 65
+        // tx = cx_ecdsa_sign(...) // ignore tx
+        cx_ecdsa_sign(&privateKey, CX_NO_CANONICAL | CX_RND_PROVIDED | CX_LAST, CX_SHA256,
                            tmpCtx.transactionContext.hash, 32, 
                            G_io_apdu_buffer + 100, 100,
                            &infos);

--- a/src/main.c
+++ b/src/main.c
@@ -193,7 +193,8 @@ UX_FLOW(
 );
 
 void display_settings() {
-    strlcpy((char *) confirmLabel, (N_storage.dataAllowed ? allowed : not_allowed),32);
+    // Review: cast destination string from volatile char to char is that ok?
+    strlcpy((char *) confirmLabel, (N_storage.dataAllowed ?  "Allowed" : "NOT Allowed"),32);
     ux_flow_init(0, ux_settings_flow, NULL);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -194,7 +194,7 @@ UX_FLOW(
 
 void display_settings() {
     // Review: cast destination string from volatile char to char is that ok?
-    strlcpy((char *) confirmLabel, (N_storage.dataAllowed ?  "Allowed" : "NOT Allowed"),32);
+    strlcpy((char *) confirmLabel, (N_storage.dataAllowed ?  "Allowed" : "NOT Allowed"),sizeof(confirmLabel));
     ux_flow_init(0, ux_settings_flow, NULL);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -393,8 +393,12 @@ void ux_single_action_sign_flow_ok_pressed()
         ux_step = 0;
         ux_step_count = txContent.argumentCount;
         snprintf((char *)confirmLabel, sizeof(confirmLabel), "Action #%d", txProcessingCtx.currentActionIndex);
-        strcpy((char *)confirm_text1, txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "Sign" : "Accept");
-        strcpy((char *)confirm_text2, txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "transaction" : "& review next");
+        strlcpy((char *)confirm_text1,
+                txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "Sign" : "Accept",
+                sizeof(confirm_text1));
+        strlcpy((char *)confirm_text2,
+               txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "transaction" : "& review next",
+               sizeof(confirm_text2));
 
         ux_flow_init(0, ux_single_action_sign_flow, NULL);
         break;
@@ -469,8 +473,12 @@ void ux_multiple_action_sign_flow_ok_pressed()
         ux_step = 0;
         ux_step_count = txContent.argumentCount;
         snprintf((char *)confirmLabel, sizeof(confirmLabel), "Action #%d", txProcessingCtx.currentActionIndex);
-        strcpy((char *)confirm_text1, txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "Sign" : "Accept");
-        strcpy((char *)confirm_text2, txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "transaction" : "& review next");
+        strlcpy((char *)confirm_text1,
+               txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "Sign" : "Accept",
+               sizeof(confirm_text1));
+        strlcpy((char *)confirm_text2,
+               txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "transaction" : "& review next",
+                sizeof(confirm_text2));
 
         ux_flow_init(0, ux_single_action_sign_flow, NULL);
 
@@ -792,11 +800,15 @@ void handleSign(uint8_t p1, uint8_t p2, uint8_t *workBuffer,
         if (txProcessingCtx.currentActionNumer > 1) {
             snprintf((char *)confirmLabel, sizeof(confirmLabel), "Action #%d", txProcessingCtx.currentActionIndex);
         } else {
-            strcpy((char *)confirmLabel, "Transaction");         
+            strlcpy((char *)confirmLabel, "Transaction", sizeof(confirmLabel));
         }
 
-        strcpy((char *)confirm_text1, txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "Sign" : "Accept");
-        strcpy((char *)confirm_text2, txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "transaction" : "& review next");
+        strlcpy((char *)confirm_text1,
+                txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "Sign" : "Accept",
+                sizeof(confirm_text1));
+        strlcpy((char *)confirm_text2,
+                txProcessingCtx.currentActionIndex == txProcessingCtx.currentActionNumer ? "transaction" : "& review next",
+                sizeof(confirm_text2));
         
         ux_flow_init(0, ux_single_action_sign_flow, NULL);
 

--- a/src/main.c
+++ b/src/main.c
@@ -985,6 +985,7 @@ void io_seproxyhal_display(const bagl_element_t *element)
 
 unsigned char io_event(unsigned char channel)
 {
+    UNUSED(channel);
     // nothing done with the event, throw an error on the transport layer if
     // needed
 


### PR DESCRIPTION
# Pull Request To Fix 15 Security Issues

Ask from Ledger to fix these issues to keep the app alive. Otherwise will be deprecated. Issues from `make scan-build`.

fixes #5, fixes #6, fixes #7, fixes #11, fixes #9, fixes #8, fixes #10, fixes #13, fixes #14, fixes #16, fixes #15, fixes #22, fixes #24, fixes #26, fixes #23, fixes #25, fixes #18, fixes #17

- main fixed a pointer compat issue in a strcpy. Cast receiving string to (char *) from volitile char *
- main moved to secure string copy using `sizeof` receiving object 
- eos_parse removed unread variable
- eos_parse moved to secure strcat for 1 char addition
- added string.h header to resolve memove undef
- correct size in strlcat
- back to inline defined strings for string copy, had undefined vars
- re-ordered statements to build buffer and then make assignment removing dead code
- removed un-used buffer-length in eos_stream
- eos_stream.c proper declaration of static inline func
- main.c cast (char *) for volatile strings in UX steps
- fixes spelling errors in comments for eos_stream.c
- fixed bug in bufferLength calc eos_parse_eosio.c
- fixed implicit declared function by including header file in eos_parse_eosio.c
- secured strcpy by moving to strlcpy
- ignore unneeded `read` value returned from call only using pass by reference `size`
- ignore signature length, for ecdsa always 64
- "wrapped channel parameter in UNUSED, call pattern needed to support external event
- clarified bagl_element_t param unused
